### PR TITLE
feat: accept config object in createApp() to consolidate settings (#31)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -269,6 +269,43 @@ export interface RouteOptimizationInfo {
   jsonFastPath?: string;
 }
 
+// ─── App Configuration ─────────────────
+
+export interface AppConfig {
+  /** Server configuration (host, port, backlog, maxHeaderBytes) */
+  server?: {
+    /** Host to bind to (default: "127.0.0.1") */
+    host?: string;
+    /** Port to bind to (default: 3000, use 0 for random) */
+    port?: number;
+    /** TCP listen backlog (default: 2048) */
+    backlog?: number;
+    /** Maximum header block size in bytes */
+    maxHeaderBytes?: number;
+  };
+
+  /** TLS/SSL configuration — set to enable HTTPS */
+  tls?: TlsConfig | null;
+
+  /** Development and optimization options */
+  dev?: {
+    /** Restart process on source changes (dev only, default: false) */
+    hotReload?: boolean;
+    /** Watch roots for hot reload */
+    hotReloadPaths?: string[];
+    /** Debounce window for restart triggers in ms (default: 120) */
+    hotReloadDebounceMs?: number;
+    /** Write dev comments above route declarations (default: true) */
+    devComments?: boolean;
+    /** Emit optimization and live-hit logs */
+    notify?: boolean;
+    /** Collect per-route dispatch timing metrics */
+    timing?: boolean;
+    /** Enable runtime response cache promotion */
+    cache?: boolean;
+  };
+}
+
 // ─── Application ────────────────────────
 
 export interface Application {
@@ -314,7 +351,7 @@ export interface Application {
 }
 
 /** Create a new http-native application */
-export function createApp(): Application;
+export function createApp(config?: AppConfig): Application;
 
 // ─── CORS Types ─────────────────────────
 

--- a/src/index.js
+++ b/src/index.js
@@ -1083,9 +1083,38 @@ async function closeNativeServerHandle(handle, timeoutMs = NATIVE_CLOSE_TIMEOUT_
  *
  * @returns {import('./index').Application}
  */
-export function createApp() {
+export function createApp(config = {}) {
   const native = loadNativeModule();
   let nextHandlerId = 1;
+
+  // Consolidate top-level config into a normalized shape that listen() can use as defaults.
+  const appConfig = {
+    server: config.server ?? {},
+    tls: config.tls ?? null,
+    dev: config.dev ?? {},
+  };
+
+  // Build default listen options from createApp config so listen() inherits them.
+  const appListenDefaults = {
+    host: appConfig.server.host,
+    port: appConfig.server.port,
+    backlog: appConfig.server.backlog,
+    serverConfig: {
+      ...(appConfig.server.maxHeaderBytes !== undefined
+        ? { maxHeaderBytes: appConfig.server.maxHeaderBytes }
+        : {}),
+      tls: appConfig.tls,
+    },
+    opt: {
+      ...(appConfig.dev.hotReload !== undefined ? { hotReload: appConfig.dev.hotReload } : {}),
+      ...(appConfig.dev.hotReloadPaths !== undefined ? { hotReloadPaths: appConfig.dev.hotReloadPaths } : {}),
+      ...(appConfig.dev.hotReloadDebounceMs !== undefined ? { hotReloadDebounceMs: appConfig.dev.hotReloadDebounceMs } : {}),
+      ...(appConfig.dev.devComments !== undefined ? { devComments: appConfig.dev.devComments } : {}),
+      ...(appConfig.dev.notify !== undefined ? { notify: appConfig.dev.notify } : {}),
+      ...(appConfig.dev.timing !== undefined ? { timing: appConfig.dev.timing } : {}),
+      ...(appConfig.dev.cache !== undefined ? { cache: appConfig.dev.cache } : {}),
+    },
+  };
 
   const app = {
     _routes: [],
@@ -1093,6 +1122,7 @@ export function createApp() {
     _errorHandlers: [],
     _wsRoutes: [],
     _groupPrefix: "/",
+    _config: appConfig,
 
     use(pathOrMiddleware, maybeMiddleware) {
       let pathPrefix = "/";
@@ -1185,7 +1215,22 @@ export function createApp() {
 
     listen(options = {}) {
       const startServer = async (listenOptions = options) => {
-        const normalizedOptions = normalizeListenOptions(listenOptions);
+        // Merge app-level defaults (from createApp config) with per-listen overrides.
+        const mergedOptions = {
+          host: listenOptions.host ?? appListenDefaults.host,
+          port: listenOptions.port ?? appListenDefaults.port,
+          backlog: listenOptions.backlog ?? appListenDefaults.backlog,
+          serverConfig: {
+            ...(appListenDefaults.serverConfig ?? {}),
+            ...(listenOptions.serverConfig ?? {}),
+            tls: listenOptions.serverConfig?.tls ?? appListenDefaults.serverConfig?.tls,
+          },
+          opt: {
+            ...(appListenDefaults.opt ?? {}),
+            ...(listenOptions.opt ?? {}),
+          },
+        };
+        const normalizedOptions = normalizeListenOptions(mergedOptions);
 
         await new Promise((resolve, reject) => {
           import("node:net").then(({ createServer }) => {


### PR DESCRIPTION
Allow createApp() to accept an optional config object that consolidates server, TLS, and dev settings in one place instead of scattering them across httpServerConfig, app.listen(), and .opt().

New usage:
  const app = createApp({
    server: { port: 8080, host: "0.0.0.0" },
    tls: { cert: "./cert.pem", key: "./key.pem" },
    dev: { hotReload: true, notify: true },
  })
  await app.listen()

Fully backward compatible — createApp() with no args still works, and app.listen(options) can still override any setting per-call.